### PR TITLE
Conversion to Qt5 signals.

### DIFF
--- a/qtmips_cli/reporter.cpp
+++ b/qtmips_cli/reporter.cpp
@@ -44,17 +44,18 @@ using namespace machine;
 using namespace std;
 
 Reporter::Reporter(QCoreApplication *app, QtMipsMachine *machine) : QObject() {
-    this->app = app;
-    this->machine = machine;
+  this->app = app;
+  this->machine = machine;
 
-    connect(machine, SIGNAL(program_exit()), this, SLOT(machine_exit()));
-    connect(machine, SIGNAL(program_trap(machine::QtMipsException&)), this, SLOT(machine_trap(machine::QtMipsException&)));
-    connect(machine->core(), SIGNAL(stop_on_exception_reached()), this, SLOT(machine_exception_reached()));
+  connect(machine, &QtMipsMachine::program_exit, this, &Reporter::machine_exit);
+  connect(machine, &QtMipsMachine::program_trap, this, &Reporter::machine_trap);
+  connect(machine->core(), &Core::stop_on_exception_reached, this,
+          &Reporter::machine_exception_reached);
 
-    e_regs = false;
-    e_cache_stats = false;
-    e_cycles = false;
-    e_fail = (enum FailReason)0;
+  e_regs = false;
+  e_cache_stats = false;
+  e_cycles = false;
+  e_fail = (enum FailReason)0;
 }
 
 void Reporter::regs() {

--- a/qtmips_cli/reporter.h
+++ b/qtmips_cli/reporter.h
@@ -42,18 +42,18 @@
 #include <QCoreApplication>
 #include "qtmipsmachine.h"
 
-class Reporter : QObject {
-    Q_OBJECT
+class Reporter : public QObject {
+  Q_OBJECT
 public:
-    Reporter(QCoreApplication *app, machine::QtMipsMachine *machine);
+  Reporter(QCoreApplication *app, machine::QtMipsMachine *machine);
 
-    void regs(); // Report status of registers
-    void cache_stats();
-    void cycles();
+  void regs(); // Report status of registers
+  void cache_stats();
+  void cycles();
 
-    enum FailReason {
-        FR_I = (1<<0), // Unsupported Instruction
-        FR_A = (1<<1), // Unsupported ALU operation
+  enum FailReason {
+    FR_I = (1 << 0), // Unsupported Instruction
+    FR_A = (1<<1), // Unsupported ALU operation
         FR_O = (1<<2), // Overflow/underflow of numerical operation
         FR_J = (1<<3), // Unaligned jump
     };

--- a/qtmips_cli/tracer.cpp
+++ b/qtmips_cli/tracer.cpp
@@ -52,54 +52,61 @@ Tracer::Tracer(QtMipsMachine *machine) {
     con_regs_hi_lo = false;
 }
 
-#define CON_RAW(VAR, FROM, SIG, SLT) do { \
-        if (!VAR) { \
-            connect(FROM, SIG, this, SLT); \
-            VAR = true;\
-        }\
-    } while(false)
-
-#define CON(VAR, FROM, SIG, SLT) \
-          CON_RAW(VAR, FROM, SIGNAL(SIG), SLOT(SLT))
+#define CON(VAR, FROM, SIG, SLT)                                               \
+  do {                                                                         \
+    if (!VAR) {                                                                \
+      connect(FROM, SIG, this, SLT);                                           \
+      VAR = true;                                                              \
+    }                                                                          \
+  } while (false)
 
 void Tracer::fetch() {
-    CON_RAW(con_fetch, machine->core(), &Core::instruction_fetched, &Tracer::instruction_fetch);
+  CON(con_fetch, machine->core(), &Core::instruction_fetched,
+      &Tracer::instruction_fetch);
 }
 
 void Tracer::decode() {
-    CON_RAW(con_decode, machine->core(), &Core::instruction_decoded, &Tracer::instruction_decode);
+  CON(con_decode, machine->core(), &Core::instruction_decoded,
+      &Tracer::instruction_decode);
 }
 
 void Tracer::execute() {
-    CON_RAW(con_execute, machine->core(), &Core::instruction_executed, &Tracer::instruction_execute);
+  CON(con_execute, machine->core(), &Core::instruction_executed,
+      &Tracer::instruction_execute);
 }
 
 void Tracer::memory() {
-    CON_RAW(con_memory, machine->core(), &Core::instruction_memory, &Tracer::instruction_memory);
+  CON(con_memory, machine->core(), &Core::instruction_memory,
+      &Tracer::instruction_memory);
 }
 
 void Tracer::writeback() {
-    CON_RAW(con_writeback, machine->core(), &Core::instruction_writeback, &Tracer::instruction_writeback);
+  CON(con_writeback, machine->core(), &Core::instruction_writeback,
+      &Tracer::instruction_writeback);
 }
 
 void Tracer::reg_pc() {
-    CON(con_regs_pc, machine->registers(), pc_update(std::uint32_t), regs_pc_update(std::uint32_t));
+  CON(con_regs_pc, machine->registers(), &Registers::pc_update,
+      &Tracer::regs_pc_update);
 }
 
 void Tracer::reg_gp(std::uint8_t i) {
-    SANITY_ASSERT(i <= 32, "Trying to trace invalid gp.");
-    CON(con_regs_gp, machine->registers(), gp_update(std::uint8_t,std::uint32_t), regs_gp_update(std::uint8_t,std::uint32_t));
-    gp_regs[i] = true;
+  SANITY_ASSERT(i <= 32, "Trying to trace invalid gp.");
+  CON(con_regs_gp, machine->registers(), &Registers::gp_update,
+      &Tracer::regs_gp_update);
+  gp_regs[i] = true;
 }
 
 void Tracer::reg_lo() {
-    CON(con_regs_hi_lo, machine->registers(), hi_lo_update(bool hi, std::uint32_t val), regs_hi_lo_update(bool hi, std::uint32_t val));
-    r_lo = true;
+  CON(con_regs_hi_lo, machine->registers(), &Registers::hi_lo_update,
+      &Tracer::regs_hi_lo_update);
+  r_lo = true;
 }
 
 void Tracer::reg_hi() {
-    CON(con_regs_hi_lo, machine->registers(), hi_lo_update(bool hi, std::uint32_t val), regs_hi_lo_update(bool hi, std::uint32_t val));
-    r_hi = true;
+  CON(con_regs_hi_lo, machine->registers(), &Registers::hi_lo_update,
+      &Tracer::regs_hi_lo_update);
+  r_hi = true;
 }
 
 void Tracer::instruction_fetch(const Instruction &inst, std::uint32_t inst_addr, ExceptionCause excause, bool valid) {

--- a/qtmips_gui/aboutdialog.cpp
+++ b/qtmips_gui/aboutdialog.cpp
@@ -128,7 +128,7 @@ AboutDialog::AboutDialog(QWidget *parent)
 
   QPushButton *okButton = new QPushButton(tr("&OK"), parent);
   okButton->setFocus();
-  connect(okButton, SIGNAL(clicked()), this, SLOT(close()));
+  connect(okButton, &QAbstractButton::clicked, this, &QWidget::close);
   hlBtn->addStretch();
   hlBtn->addWidget(okButton);
 

--- a/qtmips_gui/cachedock.cpp
+++ b/qtmips_gui/cachedock.cpp
@@ -81,11 +81,15 @@ void CacheDock::setup(const machine::Cache *cache) {
     l_hit_rate->setText("0.000%");
     l_speed->setText("100%");
     if (cache != nullptr) {
-        connect(cache, SIGNAL(hit_update(uint)), this, SLOT(hit_update(uint)));
-        connect(cache, SIGNAL(miss_update(uint)), this, SLOT(miss_update(uint)));
-        connect(cache, SIGNAL(memory_reads_update(uint)), this, SLOT(memory_reads_update(uint)));
-        connect(cache, SIGNAL(memory_writes_update(uint)), this, SLOT(memory_writes_update(uint)));
-        connect(cache, SIGNAL(statistics_update(uint,double,double)), this, SLOT(statistics_update(uint,double,double)));
+      connect(cache, &machine::Cache::hit_update, this, &CacheDock::hit_update);
+      connect(cache, &machine::Cache::miss_update, this,
+              &CacheDock::miss_update);
+      connect(cache, &machine::Cache::memory_reads_update, this,
+              &CacheDock::memory_reads_update);
+      connect(cache, &machine::Cache::memory_writes_update, this,
+              &CacheDock::memory_writes_update);
+      connect(cache, &machine::Cache::statistics_update, this,
+              &CacheDock::statistics_update);
     }
     top_form->setVisible(cache != nullptr);
     no_cache->setVisible(!cache->config().enabled());

--- a/qtmips_gui/cacheview.cpp
+++ b/qtmips_gui/cacheview.cpp
@@ -54,15 +54,16 @@ CacheAddressBlock::CacheAddressBlock(const machine::Cache *cache, unsigned width
     s_row = cache->config().sets() > 1 ? sqrt(cache->config().sets()) : 0;
     this->width = width;
     s_col = cache->config().blocks() > 1 ? sqrt(cache->config().blocks()) : 0;
-    s_tag = 30 - s_row - s_col; // 32 bits - 2 unused  and then every bit used for different index
+    s_tag = 30 - s_row - s_col; // 32 bits - 2 unused  and then every bit used
+                                // for different index
     this->width = width;
 
     tag = 0;
     row = 0;
     col = 0;
 
-    connect(cache, SIGNAL(cache_update(uint,uint,uint,bool,bool,std::uint32_t,const std::uint32_t*,bool)),
-            this, SLOT(cache_update(uint,uint,uint,bool,bool,std::uint32_t,const std::uint32_t*,bool)));
+    connect(cache, &machine::Cache::cache_update, this,
+            &CacheAddressBlock::cache_update);
 }
 
 QRectF CacheAddressBlock::boundingRect() const {
@@ -217,15 +218,16 @@ CacheViewBlock::CacheViewBlock(const machine::Cache *cache, unsigned block , boo
     QGraphicsSimpleTextItem *l_tag = new QGraphicsSimpleTextItem("Tag", this);
     l_tag->setFont(font);
     box = l_tag->boundingRect();
-    l_tag->setPos(wd + (DATA_WIDTH - box.width())/2 , -1 - box.height());
+    l_tag->setPos(wd + (DATA_WIDTH - box.width()) / 2, -1 - box.height());
     wd += DATA_WIDTH;
     QGraphicsSimpleTextItem *l_data = new QGraphicsSimpleTextItem("Data", this);
     l_data->setFont(font);
     box = l_data->boundingRect();
-    l_data->setPos(wd + (columns*DATA_WIDTH - box.width())/2 , -1 - box.height());
+    l_data->setPos(wd + (columns * DATA_WIDTH - box.width()) / 2,
+                   -1 - box.height());
 
-    connect(cache, SIGNAL(cache_update(uint,uint,uint,bool,bool,std::uint32_t,const std::uint32_t*,bool)),
-            this, SLOT(cache_update(uint,uint,uint,bool,bool,std::uint32_t,const std::uint32_t*,bool)));
+    connect(cache, &machine::Cache::cache_update, this,
+            &CacheViewBlock::cache_update);
 }
 
 CacheViewBlock::~CacheViewBlock() {

--- a/qtmips_gui/cop0dock.cpp
+++ b/qtmips_gui/cop0dock.cpp
@@ -88,13 +88,15 @@ void Cop0Dock::setup(machine::QtMipsMachine *machine) {
     const machine::Cop0State *cop0state = machine->cop0state();
 
     for (int i = 1; i < machine::Cop0State::COP0REGS_CNT; i++)
-        labelVal(cop0reg[i], cop0state->read_cop0reg((machine::Cop0State::Cop0Registers)i));
+      labelVal(cop0reg[i],
+               cop0state->read_cop0reg((machine::Cop0State::Cop0Registers)i));
 
-    connect(cop0state, &machine::Cop0State::cop0reg_update,
-            this, &Cop0Dock::cop0reg_changed);
-    connect(cop0state, &machine::Cop0State::cop0reg_read,
-            this, &Cop0Dock::cop0reg_read);
-    connect(machine, SIGNAL(tick()), this, SLOT(clear_highlights()));
+    connect(cop0state, &machine::Cop0State::cop0reg_update, this,
+            &Cop0Dock::cop0reg_changed);
+    connect(cop0state, &machine::Cop0State::cop0reg_read, this,
+            &Cop0Dock::cop0reg_read);
+    connect(machine, &machine::QtMipsMachine::tick, this,
+            &Cop0Dock::clear_highlights);
 }
 
 void Cop0Dock::cop0reg_changed(enum machine::Cop0State::Cop0Registers reg, std::uint32_t val) {

--- a/qtmips_gui/coreview/connection.cpp
+++ b/qtmips_gui/coreview/connection.cpp
@@ -88,15 +88,17 @@ QLineF Connector::vector() const {
 }
 
 Connection::Connection(const Connector *a, const Connector *b) : QGraphicsObject(nullptr) {
-    pen_width = 1;
+  pen_width = 1;
 
-    ax_start = a->vector();
-    ax_end = a->vector();
+  ax_start = a->vector();
+  ax_end = a->vector();
 
-    connect(a, SIGNAL(updated(QLineF)), this, SLOT(moved_start(QLineF)));
-    connect(b, SIGNAL(updated(QLineF)), this, SLOT(moved_end(QLineF)));
-    moved_start(a->vector());
-    moved_end(b->vector());
+  connect(a, QOverload<QLineF>::of(&Connector::updated), this,
+          &Connection::moved_start);
+  connect(b, QOverload<QLineF>::of(&Connector::updated), this,
+          &Connection::moved_end);
+  moved_start(a->vector());
+  moved_end(b->vector());
 }
 
 void Connection::setHasText(bool has) {

--- a/qtmips_gui/coreview/constant.cpp
+++ b/qtmips_gui/coreview/constant.cpp
@@ -44,14 +44,15 @@ using namespace coreview;
 //////////////////////
 
 Constant::Constant(const Connector *con, const QString &text) : QGraphicsObject(nullptr), text(text, this) {
-    QFont font;
-    font.setPixelSize(FontSize::SIZE7);
-    this->text.setFont(font);
+  QFont font;
+  font.setPixelSize(FontSize::SIZE7);
+  this->text.setFont(font);
 
-    con_our = new Connector(Connector::AX_X);
-    conn = new Bus(con_our, con, 2);
-    connect(con, SIGNAL(updated(QPointF)), this, SLOT(ref_con_updated(QPointF)));
-    ref_con_updated(con->point()); // update initial connector position
+  con_our = new Connector(Connector::AX_X);
+  conn = new Bus(con_our, con, 2);
+  connect(con, QOverload<QPointF>::of(&Connector::updated), this,
+          &Constant::ref_con_updated);
+  ref_con_updated(con->point()); // update initial connector position
 }
 
 Constant::~Constant() {

--- a/qtmips_gui/coreview/latch.cpp
+++ b/qtmips_gui/coreview/latch.cpp
@@ -58,7 +58,7 @@ Latch::Latch(machine::QtMipsMachine *machine, qreal height) : QGraphicsObject(nu
     wedge_animation->setEndValue(QColor(255, 255, 255));
     wedge_clr = QColor(255, 255, 255);
 
-    connect(machine, SIGNAL(tick()), this, SLOT(tick()));
+    connect(machine, &machine::QtMipsMachine::tick, this, &Latch::tick);
 }
 
 Latch::~Latch() {

--- a/qtmips_gui/coreview/memory.cpp
+++ b/qtmips_gui/coreview/memory.cpp
@@ -60,19 +60,21 @@ Memory::Memory(bool cache_used, const machine::Cache *cch) : QGraphicsObject(nul
 
     name.setPos(WIDTH/2 - name.boundingRect().width()/2, HEIGHT - (HEIGHT - CACHE_HEIGHT)/2);
     if (cache) {
-        const QRectF &cache_t_b = cache_t.boundingRect();
-        cache_t.setPos(WIDTH/2 - cache_t_b.width()/2, 1);
-        const QRectF &cache_hit_b = cache_hit_t.boundingRect();
-        cache_hit_t.setPos(WIDTH/20, cache_t_b.height() + 2);
-        cache_miss_t.setPos(WIDTH/20, cache_t_b.height() + cache_hit_b.height() + 3);
+      const QRectF &cache_t_b = cache_t.boundingRect();
+      cache_t.setPos(WIDTH / 2 - cache_t_b.width() / 2, 1);
+      const QRectF &cache_hit_b = cache_hit_t.boundingRect();
+      cache_hit_t.setPos(WIDTH / 20, cache_t_b.height() + 2);
+      cache_miss_t.setPos(WIDTH / 20,
+                          cache_t_b.height() + cache_hit_b.height() + 3);
     }
 
     cache_t.setVisible(cache);
     cache_hit_t.setVisible(cache);
     cache_miss_t.setVisible(cache);
 
-    connect(cch, SIGNAL(hit_update(uint)), this, SLOT(cache_hit_update(uint)));
-    connect(cch, SIGNAL(miss_update(uint)), this, SLOT(cache_miss_update(uint)));
+    connect(cch, &machine::Cache::hit_update, this, &Memory::cache_hit_update);
+    connect(cch, &machine::Cache::miss_update, this,
+            &Memory::cache_miss_update);
 
     setPos(x(), y()); // set connector's position
 }

--- a/qtmips_gui/coreview/programcounter.cpp
+++ b/qtmips_gui/coreview/programcounter.cpp
@@ -49,21 +49,23 @@ using namespace coreview;
 ProgramCounter::ProgramCounter(machine::QtMipsMachine *machine) : QGraphicsObject(nullptr), name("PC", this), value(this) {
     registers = machine->registers();
 
-    QFont font;
+  QFont font;
 
-    font.setPixelSize(FontSize::SIZE7);
-    name.setPos(WIDTH/2 - name.boundingRect().width()/2, 0);
-    name.setFont(font);
-    font.setPointSize(FontSize::SIZE8);
-    value.setText(QString("0x") + QString::number(machine->registers()->read_pc(), 16));
-    value.setPos(1, HEIGHT - value.boundingRect().height());
-    value.setFont(font);
+  font.setPixelSize(FontSize::SIZE7);
+  name.setPos(WIDTH / 2 - name.boundingRect().width() / 2, 0);
+  name.setFont(font);
+  font.setPointSize(FontSize::SIZE8);
+  value.setText(QString("0x") +
+                QString::number(machine->registers()->read_pc(), 16));
+  value.setPos(1, HEIGHT - value.boundingRect().height());
+  value.setFont(font);
 
-    connect(machine->registers(), SIGNAL(pc_update(std::uint32_t)), this, SLOT(pc_update(std::uint32_t)));
+  connect(machine->registers(), &machine::Registers::pc_update, this,
+          &ProgramCounter::pc_update);
 
-    con_in = new Connector(Connector::AX_Y);
-    con_out = new Connector(Connector::AX_Y);
-    setPos(x(), y()); // To set initial connectors positions
+  con_in = new Connector(Connector::AX_Y);
+  con_out = new Connector(Connector::AX_Y);
+  setPos(x(), y()); // To set initial connectors positions
 }
 
 ProgramCounter::~ProgramCounter() {

--- a/qtmips_gui/extprocess.cpp
+++ b/qtmips_gui/extprocess.cpp
@@ -44,11 +44,12 @@
 using namespace std;
 
 ExtProcess::ExtProcess(QObject *parent) : Super(parent) {
-    setProcessChannelMode(QProcess::MergedChannels);
-    connect(this, SIGNAL(readyReadStandardOutput()), this, SLOT(process_output()));
-    connect(this, SIGNAL(finished(int,QProcess::ExitStatus)),
-            this, SLOT(report_finished(int,QProcess::ExitStatus)));
-    connect(this, SIGNAL(started()), this, SLOT(report_started()));
+  setProcessChannelMode(QProcess::MergedChannels);
+  connect(this, &QProcess::readyReadStandardOutput, this,
+          &ExtProcess::process_output);
+  connect(this, QOverload<int, ExitStatus>::of(&QProcess::finished), this,
+          &ExtProcess::report_finished);
+  connect(this, &QProcess::started, this, &ExtProcess::report_started);
 }
 
 void ExtProcess::report_finished(int exitCode, QProcess::ExitStatus exitStatus) {

--- a/qtmips_gui/gotosymboldialog.cpp
+++ b/qtmips_gui/gotosymboldialog.cpp
@@ -1,17 +1,17 @@
 #include "gotosymboldialog.h"
 #include "ui_gotosymboldialog.h"
 
-GoToSymbolDialog::GoToSymbolDialog(QWidget *parent, QStringList &symlist) :
-    QDialog(parent),
-    ui(new Ui::GoToSymbolDialog)
-{
-    ui->setupUi(this);
+GoToSymbolDialog::GoToSymbolDialog(QWidget *parent, QStringList &symlist)
+    : QDialog(parent), ui(new Ui::GoToSymbolDialog) {
+  ui->setupUi(this);
 
-    connect(ui->pushShowProg, SIGNAL(clicked()), this, SLOT(show_prog()));
-    connect(ui->pushShowMem, SIGNAL(clicked()), this, SLOT(show_mem()));
-    connect(ui->pushClose, SIGNAL(clicked()), this, SLOT(close()));
+  connect(ui->pushShowProg, &QAbstractButton::clicked, this,
+          &GoToSymbolDialog::show_prog);
+  connect(ui->pushShowMem, &QAbstractButton::clicked, this,
+          &GoToSymbolDialog::show_mem);
+  connect(ui->pushClose, &QAbstractButton::clicked, this, &QWidget::close);
 
-    ui->listSymbols->addItems(symlist);
+  ui->listSymbols->addItems(symlist);
 }
 
 GoToSymbolDialog::~GoToSymbolDialog()

--- a/qtmips_gui/hexlineedit.cpp
+++ b/qtmips_gui/hexlineedit.cpp
@@ -60,17 +60,18 @@ HexLineEdit::HexLineEdit(QWidget *parent, int digits, int base, QString prefix):
     case 0:
     default:
         mask += "H";
-        dmask = 'h';
-        break;
+      dmask = 'h';
+      break;
     }
     if (digits > 1)
-        t.fill(dmask, digits  - 1);
+      t.fill(dmask, digits - 1);
 
     mask += t;
 
     setInputMask(mask);
 
-    connect(this, SIGNAL(editingFinished()), this, SLOT(on_edit_finished()));
+    connect(this, &QLineEdit::editingFinished, this,
+            &HexLineEdit::on_edit_finished);
 
     set_value(0);
 }

--- a/qtmips_gui/lcddisplayview.cpp
+++ b/qtmips_gui/lcddisplayview.cpp
@@ -17,18 +17,18 @@ LcdDisplayView::~LcdDisplayView() {
 }
 
 void LcdDisplayView::setup(machine::LcdDisplay *lcd_display) {
-    if (lcd_display == nullptr)
-        return;
-    connect(lcd_display, SIGNAL(pixel_update(uint,uint,uint,uint,uint)),
-            this, SLOT(pixel_update(uint,uint,uint,uint,uint)));
-    if (fb_pixels != nullptr)
-        delete fb_pixels;
-    fb_pixels = nullptr;
-    fb_pixels = new QImage(lcd_display->width(),
-                           lcd_display->height(), QImage::Format_RGB32);
-    fb_pixels->fill(qRgb(0, 0, 0));
-    update_scale();
-    update();
+  if (lcd_display == nullptr)
+    return;
+  connect(lcd_display, &machine::LcdDisplay::pixel_update, this,
+          &LcdDisplayView::pixel_update);
+  if (fb_pixels != nullptr)
+    delete fb_pixels;
+  fb_pixels = nullptr;
+  fb_pixels = new QImage(lcd_display->width(), lcd_display->height(),
+                         QImage::Format_RGB32);
+  fb_pixels->fill(qRgb(0, 0, 0));
+  update_scale();
+  update();
 }
 
 void LcdDisplayView::pixel_update(uint x, uint y, uint r, uint g, uint b) {

--- a/qtmips_gui/mainwindow.cpp
+++ b/qtmips_gui/mainwindow.cpp
@@ -115,68 +115,97 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent) {
     ui->ips1->setChecked(true);
 
     // Connect signals from menu
-    connect(ui->actionExit, SIGNAL(triggered(bool)), this, SLOT(close()));
-    connect(ui->actionNewMachine, SIGNAL(triggered(bool)), this, SLOT(new_machine()));
-    connect(ui->actionReload, SIGNAL(triggered(bool)), this, SLOT(machine_reload()));
-    connect(ui->actionPrint, SIGNAL(triggered(bool)), this, SLOT(print_action()));
-    connect(ui->actionNew, SIGNAL(triggered(bool)), this, SLOT(new_source()));
-    connect(ui->actionOpen, SIGNAL(triggered(bool)), this, SLOT(open_source()));
-    connect(ui->actionSave, SIGNAL(triggered(bool)), this, SLOT(save_source()));
-    connect(ui->actionSaveAs, SIGNAL(triggered(bool)), this, SLOT(save_source_as()));
-    connect(ui->actionClose, SIGNAL(triggered(bool)), this, SLOT(close_source_check()));
-    connect(ui->actionMnemonicRegisters, SIGNAL(triggered(bool)), this, SLOT(view_mnemonics_registers(bool)));
-    connect(ui->actionCompileSource, SIGNAL(triggered(bool)), this, SLOT(compile_source()));
-    connect(ui->actionBuildExe, SIGNAL(triggered(bool)), this, SLOT(build_execute()));
-    connect(ui->actionShow_Symbol, SIGNAL(triggered(bool)), this, SLOT(show_symbol_dialog()));
-    connect(ui->actionRegisters, SIGNAL(triggered(bool)), this, SLOT(show_registers()));
-    connect(ui->actionProgram_memory, SIGNAL(triggered(bool)), this, SLOT(show_program()));
-    connect(ui->actionMemory, SIGNAL(triggered(bool)), this, SLOT(show_memory()));
-    connect(ui->actionProgram_Cache, SIGNAL(triggered(bool)), this, SLOT(show_cache_program()));
-    connect(ui->actionData_Cache, SIGNAL(triggered(bool)), this, SLOT(show_cache_data()));
-    connect(ui->actionPeripherals, SIGNAL(triggered(bool)), this, SLOT(show_peripherals()));
-    connect(ui->actionTerminal, SIGNAL(triggered(bool)), this, SLOT(show_terminal()));
-    connect(ui->actionLcdDisplay, SIGNAL(triggered(bool)), this, SLOT(show_lcd_display()));
-    connect(ui->actionCop0State, SIGNAL(triggered(bool)), this, SLOT(show_cop0dock()));
-    connect(ui->actionCore_View_show, SIGNAL(triggered(bool)), this, SLOT(show_hide_coreview(bool)));
-    connect(ui->actionMessages, SIGNAL(triggered(bool)), this, SLOT(show_messages()));
-    connect(ui->actionAbout, SIGNAL(triggered(bool)), this, SLOT(about_qtmips()));
-    connect(ui->actionAboutQt, SIGNAL(triggered(bool)), this, SLOT(about_qt()));
-    connect(ui->ips1, SIGNAL(toggled(bool)), this, SLOT(set_speed()));
-    connect(ui->ips2, SIGNAL(toggled(bool)), this, SLOT(set_speed()));
-    connect(ui->ips5, SIGNAL(toggled(bool)), this, SLOT(set_speed()));
-    connect(ui->ips10, SIGNAL(toggled(bool)), this, SLOT(set_speed()));
-    connect(ui->ipsUnlimited, SIGNAL(toggled(bool)), this, SLOT(set_speed()));
-    connect(ui->ipsMax, SIGNAL(toggled(bool)), this, SLOT(set_speed()));
+    connect(ui->actionExit, &QAction::triggered, this, &QWidget::close);
+    connect(ui->actionNewMachine, &QAction::triggered, this,
+            &MainWindow::new_machine);
+    connect(ui->actionReload, &QAction::triggered, this,
+            std::bind(&MainWindow::machine_reload, this, false, false));
+    connect(ui->actionPrint, &QAction::triggered, this,
+            &MainWindow::print_action);
+    connect(ui->actionNew, &QAction::triggered, this, &MainWindow::new_source);
+    connect(ui->actionOpen, &QAction::triggered, this,
+            &MainWindow::open_source);
+    connect(ui->actionSave, &QAction::triggered, this,
+            &MainWindow::save_source);
+    connect(ui->actionSaveAs, &QAction::triggered, this,
+            &MainWindow::save_source_as);
+    connect(ui->actionClose, &QAction::triggered, this,
+            &MainWindow::close_source_check);
+    connect(ui->actionMnemonicRegisters, &QAction::triggered, this,
+            &MainWindow::view_mnemonics_registers);
+    connect(ui->actionCompileSource, &QAction::triggered, this,
+            &MainWindow::compile_source);
+    connect(ui->actionBuildExe, &QAction::triggered, this,
+            &MainWindow::build_execute);
+    connect(ui->actionShow_Symbol, &QAction::triggered, this,
+            &MainWindow::show_symbol_dialog);
+    connect(ui->actionRegisters, &QAction::triggered, this,
+            &MainWindow::show_registers);
+    connect(ui->actionProgram_memory, &QAction::triggered, this,
+            &MainWindow::show_program);
+    connect(ui->actionMemory, &QAction::triggered, this,
+            &MainWindow::show_memory);
+    connect(ui->actionProgram_Cache, &QAction::triggered, this,
+            &MainWindow::show_cache_program);
+    connect(ui->actionData_Cache, &QAction::triggered, this,
+            &MainWindow::show_cache_data);
+    connect(ui->actionPeripherals, &QAction::triggered, this,
+            &MainWindow::show_peripherals);
+    connect(ui->actionTerminal, &QAction::triggered, this,
+            &MainWindow::show_terminal);
+    connect(ui->actionLcdDisplay, &QAction::triggered, this,
+            &MainWindow::show_lcd_display);
+    connect(ui->actionCop0State, &QAction::triggered, this,
+            &MainWindow::show_cop0dock);
+    connect(ui->actionCore_View_show, &QAction::triggered, this,
+            &MainWindow::show_hide_coreview);
+    connect(ui->actionMessages, &QAction::triggered, this,
+            &MainWindow::show_messages);
+    connect(ui->actionAbout, &QAction::triggered, this,
+            &MainWindow::about_qtmips);
+    connect(ui->actionAboutQt, &QAction::triggered, this,
+            &MainWindow::about_qt);
+    connect(ui->ips1, &QAction::toggled, this, &MainWindow::set_speed);
+    connect(ui->ips2, &QAction::toggled, this, &MainWindow::set_speed);
+    connect(ui->ips5, &QAction::toggled, this, &MainWindow::set_speed);
+    connect(ui->ips10, &QAction::toggled, this, &MainWindow::set_speed);
+    connect(ui->ipsUnlimited, &QAction::toggled, this, &MainWindow::set_speed);
+    connect(ui->ipsMax, &QAction::toggled, this, &MainWindow::set_speed);
 
-    connect(this, SIGNAL(report_message(messagetype::Type,QString,int,int,QString,QString)),
-            messages, SLOT(insert_line(messagetype::Type,QString,int,int,QString,QString)));
-    connect(this, SIGNAL(clear_messages()), messages, SLOT(clear_messages()));
-    connect(messages, SIGNAL(message_selected(messagetype::Type,QString,int,int,QString,QString)),
-            this, SLOT(message_selected(messagetype::Type,QString,int,int,QString,QString)));
+    connect(this, &MainWindow::report_message, messages,
+            &MessagesDock::insert_line);
+    connect(this, &MainWindow::clear_messages, messages,
+            &MessagesDock::clear_messages);
+    connect(messages, &MessagesDock::message_selected, this,
+            &MainWindow::message_selected);
 
     // Restore application state from settings
     restoreState(settings->value("windowState").toByteArray());
     restoreGeometry(settings->value("windowGeometry").toByteArray());
 
     // Source editor related actions
-    connect(central_window, SIGNAL(currentChanged(int)), this, SLOT(central_tab_changed(int)));
+    connect(central_window, &QTabWidget::currentChanged, this,
+            &MainWindow::central_tab_changed);
 
-    foreach (QString file_name, settings->value("openSrcFiles").toStringList()) {
-        if (file_name.isEmpty())
-            continue;
-        SrcEditor *editor = new SrcEditor();
-        if (editor->loadFile(file_name)) {
-            add_src_editor_to_tabs(editor);
-        } else {
-            delete(editor);
-        }
+    foreach (QString file_name,
+             settings->value("openSrcFiles").toStringList()) {
+      if (file_name.isEmpty())
+        continue;
+      SrcEditor *editor = new SrcEditor();
+      if (editor->loadFile(file_name)) {
+        add_src_editor_to_tabs(editor);
+      } else {
+        delete (editor);
+      }
     }
 
     QDir samples_dir(":/samples");
     for (QString fname: samples_dir.entryList(QDir::Files)) {
-        TextSignalAction *textsigac = new TextSignalAction(fname, ":/samples/" + fname);
-        ui->menuExamples->addAction(textsigac);
-        connect(textsigac, SIGNAL( activated(QString)), this, SLOT(example_source(QString)));
+      TextSignalAction *textsigac =
+          new TextSignalAction(fname, ":/samples/" + fname);
+      ui->menuExamples->addAction(textsigac);
+      connect(textsigac, &TextSignalAction::activated, this,
+              &MainWindow::example_source);
     }
 
 #ifdef __EMSCRIPTEN__
@@ -223,22 +252,30 @@ void MainWindow::show_hide_coreview(bool show) {
         return;
     }
     if (show && (corescene != nullptr))
-        return;
+      return;
 
     if (machine->config().pipelined()) {
-        corescene = new CoreViewScenePipelined(machine);
+      corescene = new CoreViewScenePipelined(machine);
     } else {
-        corescene = new CoreViewSceneSimple(machine);
+      corescene = new CoreViewSceneSimple(machine);
     }
     // Connect scene signals to actions
-    connect(corescene, SIGNAL(request_registers()), this, SLOT(show_registers()));
-    connect(corescene, SIGNAL(request_program_memory()), this, SLOT(show_program()));
-    connect(corescene, SIGNAL(request_data_memory()), this, SLOT(show_memory()));
-    connect(corescene, SIGNAL(request_jump_to_program_counter(std::uint32_t)), program, SIGNAL(jump_to_pc(std::uint32_t)));
-    connect(corescene, SIGNAL(request_cache_program()), this, SLOT(show_cache_program()));
-    connect(corescene, SIGNAL(request_cache_data()), this, SLOT(show_cache_data()));
-    connect(corescene, SIGNAL(request_peripherals()), this, SLOT(show_peripherals()));
-    connect(corescene, SIGNAL(request_terminal()), this, SLOT(show_terminal()));
+    connect(corescene, &CoreViewScene::request_registers, this,
+            &MainWindow::show_registers);
+    connect(corescene, &CoreViewScene::request_program_memory, this,
+            &MainWindow::show_program);
+    connect(corescene, &CoreViewScene::request_data_memory, this,
+            &MainWindow::show_memory);
+    connect(corescene, &CoreViewScene::request_jump_to_program_counter, program,
+            &ProgramDock::jump_to_pc);
+    connect(corescene, &CoreViewScene::request_cache_program, this,
+            &MainWindow::show_cache_program);
+    connect(corescene, &CoreViewScene::request_cache_data, this,
+            &MainWindow::show_cache_data);
+    connect(corescene, &CoreViewScene::request_peripherals, this,
+            &MainWindow::show_peripherals);
+    connect(corescene, &CoreViewScene::request_terminal, this,
+            &MainWindow::show_terminal);
     coreview->setScene(corescene);
 }
 
@@ -265,33 +302,43 @@ void MainWindow::create_core(const machine::MachineConfig &config, bool load_exe
     set_speed(); // Update machine speed to current settings
 
     if (config.osemu_enable()) {
-        osemu::OsSyscallExceptionHandler *osemu_handler =
-                new osemu::OsSyscallExceptionHandler(config.osemu_known_syscall_stop(),
-                                                     config.osemu_unknown_syscall_stop(),
-                                                     config.osemu_fs_root());
-        machine->register_exception_handler(machine::EXCAUSE_SYSCALL, osemu_handler);
-        connect(osemu_handler, SIGNAL(char_written(int,uint)), terminal, SLOT(tx_byte(int,uint)));
-        connect(osemu_handler, SIGNAL(rx_byte_pool(int,uint&,bool&)),
-            terminal, SLOT(rx_byte_pool(int,uint&,bool&)));
-        machine->set_step_over_exception(machine::EXCAUSE_SYSCALL, true);
-        machine->set_stop_on_exception(machine::EXCAUSE_SYSCALL, false);
+      osemu::OsSyscallExceptionHandler *osemu_handler =
+          new osemu::OsSyscallExceptionHandler(
+              config.osemu_known_syscall_stop(),
+              config.osemu_unknown_syscall_stop(), config.osemu_fs_root());
+      machine->register_exception_handler(machine::EXCAUSE_SYSCALL,
+                                          osemu_handler);
+      connect(osemu_handler, &osemu::OsSyscallExceptionHandler::char_written,
+              terminal,
+              QOverload<int, unsigned int>::of(&TerminalDock::tx_byte));
+      connect(osemu_handler, &osemu::OsSyscallExceptionHandler::rx_byte_pool,
+              terminal, &TerminalDock::rx_byte_pool);
+      machine->set_step_over_exception(machine::EXCAUSE_SYSCALL, true);
+      machine->set_stop_on_exception(machine::EXCAUSE_SYSCALL, false);
     } else {
-        machine->set_step_over_exception(machine::EXCAUSE_SYSCALL, false);
-        machine->set_stop_on_exception(machine::EXCAUSE_SYSCALL,
-                                               config.osemu_exception_stop());
+      machine->set_step_over_exception(machine::EXCAUSE_SYSCALL, false);
+      machine->set_stop_on_exception(machine::EXCAUSE_SYSCALL,
+                                     config.osemu_exception_stop());
     }
 
     // Connect machine signals and slots
-    connect(ui->actionRun, SIGNAL(triggered(bool)), machine, SLOT(play()));
-    connect(ui->actionPause, SIGNAL(triggered(bool)), machine, SLOT(pause()));
-    connect(ui->actionStep, SIGNAL(triggered(bool)), machine, SLOT(step()));
-    connect(ui->actionRestart, SIGNAL(triggered(bool)), machine, SLOT(restart()));
-    connect(machine, SIGNAL(status_change(machine::QtMipsMachine::Status)), this, SLOT(machine_status(machine::QtMipsMachine::Status)));
-    connect(machine, SIGNAL(program_exit()), this, SLOT(machine_exit()));
-    connect(machine, SIGNAL(program_trap(machine::QtMipsException&)), this, SLOT(machine_trap(machine::QtMipsException&)));
+    connect(ui->actionRun, &QAction::triggered, machine,
+            &machine::QtMipsMachine::play);
+    connect(ui->actionPause, &QAction::triggered, machine,
+            &machine::QtMipsMachine::pause);
+    connect(ui->actionStep, &QAction::triggered, machine,
+            &machine::QtMipsMachine::step);
+    connect(ui->actionRestart, &QAction::triggered, machine,
+            &machine::QtMipsMachine::restart);
+    connect(machine, &machine::QtMipsMachine::status_change, this,
+            &MainWindow::machine_status);
+    connect(machine, &machine::QtMipsMachine::program_exit, this,
+            &MainWindow::machine_exit);
+    connect(machine, &machine::QtMipsMachine::program_trap, this,
+            &MainWindow::machine_trap);
     // Connect signal from break to machine pause
-    connect(machine->core(), SIGNAL(stop_on_exception_reached()), machine, SLOT(pause()));
-
+    connect(machine->core(), &machine::Core::stop_on_exception_reached, machine,
+            &machine::QtMipsMachine::pause);
 
     // Setup docks
     registers->setup(machine);
@@ -305,16 +352,16 @@ void MainWindow::create_core(const machine::MachineConfig &config, bool load_exe
     cop0dock->setup(machine);
 
     // Connect signals for instruction address followup
-    connect(machine->core(), SIGNAL(fetch_inst_addr_value(std::uint32_t)),
-            program, SLOT(fetch_inst_addr(std::uint32_t)));
-    connect(machine->core(), SIGNAL(decode_inst_addr_value(std::uint32_t)),
-            program, SLOT(decode_inst_addr(std::uint32_t)));
-    connect(machine->core(), SIGNAL(execute_inst_addr_value(std::uint32_t)),
-            program, SLOT(execute_inst_addr(std::uint32_t)));
-    connect(machine->core(), SIGNAL(memory_inst_addr_value(std::uint32_t)),
-            program, SLOT(memory_inst_addr(std::uint32_t)));
-    connect(machine->core(), SIGNAL(writeback_inst_addr_value(std::uint32_t)),
-            program, SLOT(writeback_inst_addr(std::uint32_t)));
+    connect(machine->core(), &machine::Core::fetch_inst_addr_value, program,
+            &ProgramDock::fetch_inst_addr);
+    connect(machine->core(), &machine::Core::decode_inst_addr_value, program,
+            &ProgramDock::decode_inst_addr);
+    connect(machine->core(), &machine::Core::execute_inst_addr_value, program,
+            &ProgramDock::execute_inst_addr);
+    connect(machine->core(), &machine::Core::memory_inst_addr_value, program,
+            &ProgramDock::memory_inst_addr);
+    connect(machine->core(), &machine::Core::writeback_inst_addr_value, program,
+            &ProgramDock::writeback_inst_addr);
 
     // Set status to ready
     machine_status(machine::QtMipsMachine::ST_READY);
@@ -392,24 +439,24 @@ SHOW_HANDLER(cop0dock, Qt::TopDockWidgetArea)
 SHOW_HANDLER(messages, Qt::BottomDockWidgetArea)
 #undef SHOW_HANDLER
 
-void MainWindow::show_symbol_dialog(){
-    if (machine == nullptr || machine->symbol_table() == nullptr)
-        return;
-    QStringList *symnames = machine->symbol_table()->names();
-    GoToSymbolDialog *gotosyboldialog = new GoToSymbolDialog(this, *symnames);
-    delete symnames;
-    connect(gotosyboldialog, SIGNAL(program_focus_addr(std::uint32_t)),
-            program, SIGNAL(focus_addr_with_save(std::uint32_t)));
-    connect(gotosyboldialog, SIGNAL(program_focus_addr(std::uint32_t)),
-            this, SLOT(show_program()));
-    connect(gotosyboldialog, SIGNAL(memory_focus_addr(std::uint32_t)),
-            memory, SIGNAL(focus_addr(std::uint32_t)));
-    connect(gotosyboldialog, SIGNAL(memory_focus_addr(std::uint32_t)),
-            this, SLOT(show_memory()));
-    connect(gotosyboldialog, SIGNAL(obtain_value_for_name(std::uint32_t&,QString)),
-            machine->symbol_table(), SLOT(name_to_value(std::uint32_t&,QString)));
-    gotosyboldialog->setAttribute(Qt::WA_DeleteOnClose);
-    gotosyboldialog->open();
+void MainWindow::show_symbol_dialog() {
+  if (machine == nullptr || machine->symbol_table() == nullptr)
+    return;
+  QStringList *symnames = machine->symbol_table()->names();
+  GoToSymbolDialog *gotosyboldialog = new GoToSymbolDialog(this, *symnames);
+  delete symnames;
+  connect(gotosyboldialog, &GoToSymbolDialog::program_focus_addr, program,
+          &ProgramDock::focus_addr_with_save);
+  connect(gotosyboldialog, &GoToSymbolDialog::program_focus_addr, this,
+          &MainWindow::show_program);
+  connect(gotosyboldialog, &GoToSymbolDialog::memory_focus_addr, memory,
+          &MemoryDock::focus_addr);
+  connect(gotosyboldialog, &GoToSymbolDialog::memory_focus_addr, this,
+          &MainWindow::show_memory);
+  connect(gotosyboldialog, &GoToSymbolDialog::obtain_value_for_name,
+          machine->symbol_table(), &machine::SymbolTable::name_to_value);
+  gotosyboldialog->setAttribute(Qt::WA_DeleteOnClose);
+  gotosyboldialog->open();
 }
 
 void MainWindow::about_qtmips()
@@ -455,16 +502,15 @@ void MainWindow::closeEvent(QCloseEvent *event) {
 
     QStringList list;
     if (modified_file_list(list, true) && !ignore_unsaved) {
-        event->ignore();
-        SaveChnagedDialog *dialog = new SaveChnagedDialog(list, this);
-        int id = qMetaTypeId<QStringList>();
-        if(!QMetaType::isRegistered(id)) {
-                qRegisterMetaType<QStringList>();
-        }
-        connect(dialog, SIGNAL(user_decision(bool,QStringList)),
-                this, SLOT(save_exit_or_ignore(bool,QStringList)),
-                Qt::QueuedConnection);
-        dialog->open();
+      event->ignore();
+      SaveChnagedDialog *dialog = new SaveChnagedDialog(list, this);
+      int id = qMetaTypeId<QStringList>();
+      if (!QMetaType::isRegistered(id)) {
+        qRegisterMetaType<QStringList>();
+      }
+      connect(dialog, &SaveChnagedDialog::user_decision, this,
+              &MainWindow::save_exit_or_ignore, Qt::QueuedConnection);
+      dialog->open();
     }
 }
 
@@ -593,9 +639,9 @@ void MainWindow::central_tab_changed(int index) {
 }
 
 void MainWindow::add_src_editor_to_tabs(SrcEditor *editor) {
-    central_window->addTab(editor, editor->title());
-    central_window->setCurrentWidget(editor);
-    connect(editor, SIGNAL(destroyed(QObject*)), this, SLOT(tab_widget_destroyed(QObject*)));
+  central_window->addTab(editor, editor->title());
+  central_window->setCurrentWidget(editor);
+  connect(editor, &QObject::destroyed, this, &MainWindow::tab_widget_destroyed);
 }
 
 void MainWindow::update_open_file_list() {
@@ -739,15 +785,15 @@ void MainWindow::save_source_as() {
 #else
     QString filename = current_srceditor->filename();
     if (filename.isEmpty())
-        filename = "unknown.s";
+      filename = "unknown.s";
     QInputDialog *dialog = new QInputDialog(this);
     dialog->setWindowTitle("Select file name");
     dialog->setLabelText("File name:");
     dialog->setTextValue(filename);
     dialog->setMinimumSize(QSize(200, 100));
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    connect(dialog, SIGNAL(textValueSelected(QString)),
-            this, SLOT(src_editor_save_to(QString)), Qt::QueuedConnection);
+    connect(dialog, &QInputDialog::textValueSelected, this,
+            &MainWindow::src_editor_save_to, Qt::QueuedConnection);
     dialog->open();
 #endif
 }
@@ -782,23 +828,24 @@ void MainWindow::save_source() {
 
 void MainWindow::close_source_check() {
     if (current_srceditor == nullptr)
-        return;
-    SrcEditor *editor = current_srceditor;
-    if (!editor->isModified()) {
-        close_source();
-        return;
-    }
-    QMessageBox *msgbox = new QMessageBox(this);
-    msgbox->setWindowTitle("Close unsaved source");
-    msgbox->setText("Close unsaved source.");
-    msgbox->setInformativeText("Do you want to save your changes?");
-    msgbox->setStandardButtons(QMessageBox::Save | QMessageBox::Discard | QMessageBox::Cancel);
-    msgbox->setDefaultButton(QMessageBox::Save);
-    msgbox->setMinimumSize(QSize(200, 150));
-    msgbox->setAttribute(Qt::WA_DeleteOnClose);
-    connect(msgbox, SIGNAL(finished(int)),
-            this, SLOT(close_source_decided(int)), Qt::QueuedConnection);
-    msgbox->open();
+    return;
+  SrcEditor *editor = current_srceditor;
+  if (!editor->isModified()) {
+    close_source();
+    return;
+  }
+  QMessageBox *msgbox = new QMessageBox(this);
+  msgbox->setWindowTitle("Close unsaved source");
+  msgbox->setText("Close unsaved source.");
+  msgbox->setInformativeText("Do you want to save your changes?");
+  msgbox->setStandardButtons(QMessageBox::Save | QMessageBox::Discard |
+                             QMessageBox::Cancel);
+  msgbox->setDefaultButton(QMessageBox::Save);
+  msgbox->setMinimumSize(QSize(200, 150));
+  msgbox->setAttribute(Qt::WA_DeleteOnClose);
+  connect(msgbox, &QDialog::finished, this, &MainWindow::close_source_decided,
+          Qt::QueuedConnection);
+  msgbox->open();
 }
 
 void MainWindow::close_source_decided(int result) {
@@ -968,19 +1015,20 @@ void MainWindow::compile_source() {
     emit clear_messages();
     SimpleAsmWithEditorCheck sasm(this);
 
-    connect(&sasm, SIGNAL(report_message(messagetype::Type,QString,int,int,QString,QString)),
-            this, SIGNAL(report_message(messagetype::Type,QString,int,int,QString,QString)));
+    connect(&sasm, &SimpleAsm::report_message, this,
+            &MainWindow::report_message);
 
     sasm.setup(mem, &symtab, 0x80020000);
 
     int ln = 1;
-    for ( QTextBlock block = doc->begin(); block.isValid(); block = block.next(), ln++) {
-        QString line = block.text();
-        if (!sasm.process_line(line, filename, ln))
-            error_occured = true;
+    for (QTextBlock block = doc->begin(); block.isValid();
+         block = block.next(), ln++) {
+      QString line = block.text();
+      if (!sasm.process_line(line, filename, ln))
+        error_occured = true;
     }
     if (!sasm.finish())
-        error_occured = true;
+      error_occured = true;
 
     if (error_occured)
         show_messages();
@@ -989,10 +1037,10 @@ void MainWindow::compile_source() {
 void MainWindow::build_execute() {
     QStringList list;
     if (modified_file_list(list)) {
-        SaveChnagedDialog *dialog = new SaveChnagedDialog(list, this);
-        connect(dialog, SIGNAL(user_decision(bool,QStringList)),
-                this, SLOT(build_execute_with_save(bool,QStringList)));
-        dialog->open();
+      SaveChnagedDialog *dialog = new SaveChnagedDialog(list, this);
+      connect(dialog, &SaveChnagedDialog::user_decision, this,
+              &MainWindow::build_execute_with_save);
+      dialog->open();
     } else {
         build_execute_no_check();
     }
@@ -1013,29 +1061,29 @@ void MainWindow::build_execute_no_check() {
     ExtProcess *proc;
     ExtProcess *procptr = build_process;
     if (procptr != nullptr) {
-        procptr->close();
-        procptr->deleteLater();
+      procptr->close();
+      procptr->deleteLater();
     }
 
     emit clear_messages();
     show_messages();
     proc = new ExtProcess(this);
     build_process = procptr;
-    connect(proc, SIGNAL(report_message(messagetype::Type,QString,int,int,QString,QString)),
-            this, SIGNAL(report_message(messagetype::Type,QString,int,int,QString,QString)));
-    connect(proc, SIGNAL(finished(int,QProcess::ExitStatus)),
-            this, SLOT(build_execute_finished(int,QProcess::ExitStatus)));
+    connect(proc, &ExtProcess::report_message, this,
+            &MainWindow::report_message);
+    connect(proc, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, &MainWindow::build_execute_finished);
     if (current_srceditor != nullptr) {
-        if (!current_srceditor->filename().isEmpty()) {
-            QFileInfo fi(current_srceditor->filename());
-            work_dir = fi.dir().path();
-        }
+      if (!current_srceditor->filename().isEmpty()) {
+        QFileInfo fi(current_srceditor->filename());
+        work_dir = fi.dir().path();
+      }
     }
     if (work_dir.isEmpty() && (machine != nullptr)) {
-        if (!machine->config().elf().isEmpty()) {
-            QFileInfo fi(machine->config().elf());
-            work_dir = fi.dir().path();
-        }
+      if (!machine->config().elf().isEmpty()) {
+        QFileInfo fi(machine->config().elf());
+        work_dir = fi.dir().path();
+      }
     }
     if (!work_dir.isEmpty())
         proc->setWorkingDirectory(work_dir);

--- a/qtmips_gui/memorymodel.cpp
+++ b/qtmips_gui/memorymodel.cpp
@@ -168,14 +168,17 @@ QVariant MemoryModel::data(const QModelIndex &index, int role) const {
 }
 
 void MemoryModel::setup(machine::QtMipsMachine *machine) {
-    this->machine = machine;
-    if (machine != nullptr)
-        connect(machine, SIGNAL(post_tick()), this, SLOT(check_for_updates()));
-    if (mem_access() != nullptr)
-        connect(mem_access(), SIGNAL(external_change_notify(const MemoryAccess*,std::uint32_t,std::uint32_t,bool)),
-                this, SLOT(check_for_updates()));
-    emit update_all();
-    emit setup_done();
+  this->machine = machine;
+  if (machine != nullptr) {
+    connect(machine, &machine::QtMipsMachine::post_tick, this,
+            &MemoryModel::check_for_updates);
+  }
+  if (mem_access() != nullptr) {
+    connect(mem_access(), &machine::MemoryAccess::external_change_notify, this,
+            &MemoryModel::check_for_updates);
+  }
+  emit update_all();
+  emit setup_done();
 }
 
 void MemoryModel::setCellsPerRow(unsigned int cells) {

--- a/qtmips_gui/memorytableview.cpp
+++ b/qtmips_gui/memorytableview.cpp
@@ -44,15 +44,15 @@
 #include "hinttabledelegate.h"
 
 MemoryTableView::MemoryTableView(QWidget *parent, QSettings *settings) : Super(parent) {
-    setItemDelegate(new HintTableDelegate);
-    connect(verticalScrollBar() , SIGNAL(valueChanged(int)),
-            this, SLOT(adjust_scroll_pos_check()));
-    connect(this , SIGNAL(adjust_scroll_pos_queue()),
-            this, SLOT(adjust_scroll_pos_process()), Qt::QueuedConnection);
-    this->settings = settings;
-    initial_address = settings->value("DataViewAddr0", 0).toULongLong();
-    adjust_scroll_pos_in_progress = false;
-    setTextElideMode(Qt::ElideNone);
+  setItemDelegate(new HintTableDelegate);
+  connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this,
+          &MemoryTableView::adjust_scroll_pos_check);
+  connect(this, &MemoryTableView::adjust_scroll_pos_queue, this,
+          &MemoryTableView::adjust_scroll_pos_process, Qt::QueuedConnection);
+  this->settings = settings;
+  initial_address = settings->value("DataViewAddr0", 0).toULongLong();
+  adjust_scroll_pos_in_progress = false;
+  setTextElideMode(Qt::ElideNone);
 }
 
 void MemoryTableView::addr0_save_change(std::uint32_t val) {

--- a/qtmips_gui/messagesdock.cpp
+++ b/qtmips_gui/messagesdock.cpp
@@ -69,12 +69,14 @@ MessagesDock::MessagesDock(QWidget *parent, QSettings *settings) : Super(parent)
 
     setWidget(content);
 
-    connect(this, SIGNAL(report_message(messagetype::Type,QString,int,int,QString,QString)),
-    messages_model, SLOT(insert_line(messagetype::Type,QString,int,int,QString,QString)));
-    connect(this, SIGNAL(pass_clear_messages()), messages_model, SLOT(clear_messages()));
-    connect(messages_content, SIGNAL(activated(QModelIndex)), messages_model, SLOT(activated(QModelIndex)));
-    connect(messages_model, SIGNAL(message_selected(messagetype::Type,QString,int,int,QString,QString)),
-            this, SIGNAL(message_selected(messagetype::Type,QString,int,int,QString,QString)));
+    connect(this, &MessagesDock::report_message, messages_model,
+            &MessagesModel::insert_line);
+    connect(this, &MessagesDock::pass_clear_messages, messages_model,
+            &MessagesModel::clear_messages);
+    connect(messages_content, &QAbstractItemView::activated, messages_model,
+            &MessagesModel::activated);
+    connect(messages_model, &MessagesModel::message_selected, this,
+            &MessagesDock::message_selected);
 }
 
 void MessagesDock::insert_line(messagetype::Type type, QString file, int line,

--- a/qtmips_gui/newdialog.cpp
+++ b/qtmips_gui/newdialog.cpp
@@ -57,39 +57,66 @@ NewDialog::NewDialog(QWidget *parent, QSettings *settings) : QDialog(parent) {
     ui_cache_d = new Ui::NewDialogCache();
     ui_cache_d->setupUi(ui->tab_cache_data);
 
-    connect(ui->pushButton_start_empty, SIGNAL(clicked(bool)), this, SLOT(create_empty()));
-    connect(ui->pushButton_load, SIGNAL(clicked(bool)), this, SLOT(create()));
-    connect(ui->pushButton_cancel, SIGNAL(clicked(bool)), this, SLOT(cancel()));
-    connect(ui->pushButton_browse, SIGNAL(clicked(bool)), this, SLOT(browse_elf()));
-    connect(ui->elf_file, SIGNAL(textChanged(QString)), this, SLOT(elf_change(QString)));
-    connect(ui->preset_no_pipeline, SIGNAL(toggled(bool)), this, SLOT(set_preset()));
-    connect(ui->preset_no_pipeline_cache, SIGNAL(toggled(bool)), this, SLOT(set_preset()));
-    connect(ui->preset_pipelined_bare, SIGNAL(toggled(bool)), this, SLOT(set_preset()));
-    connect(ui->preset_pipelined, SIGNAL(toggled(bool)), this, SLOT(set_preset()));
-    connect(ui->reset_at_compile, SIGNAL(clicked(bool)), this, SLOT(reset_at_compile_change(bool)));
+    connect(ui->pushButton_start_empty, &QAbstractButton::clicked, this,
+            &NewDialog::create_empty);
+    connect(ui->pushButton_load, &QAbstractButton::clicked, this,
+            &NewDialog::create);
+    connect(ui->pushButton_cancel, &QAbstractButton::clicked, this,
+            &NewDialog::cancel);
+    connect(ui->pushButton_browse, &QAbstractButton::clicked, this,
+            &NewDialog::browse_elf);
+    connect(ui->elf_file, &QLineEdit::textChanged, this,
+            &NewDialog::elf_change);
+    connect(ui->preset_no_pipeline, &QAbstractButton::toggled, this,
+            &NewDialog::set_preset);
+    connect(ui->preset_no_pipeline_cache, &QAbstractButton::toggled, this,
+            &NewDialog::set_preset);
+    connect(ui->preset_pipelined_bare, &QAbstractButton::toggled, this,
+            &NewDialog::set_preset);
+    connect(ui->preset_pipelined, &QAbstractButton::toggled, this,
+            &NewDialog::set_preset);
+    connect(ui->reset_at_compile, &QAbstractButton::clicked, this,
+            &NewDialog::reset_at_compile_change);
 
-    connect(ui->pipelined, SIGNAL(clicked(bool)), this, SLOT(pipelined_change(bool)));
-    connect(ui->delay_slot, SIGNAL(clicked(bool)), this, SLOT(delay_slot_change(bool)));
-    connect(ui->hazard_unit, SIGNAL(clicked(bool)), this, SLOT(hazard_unit_change()));
-    connect(ui->hazard_stall, SIGNAL(clicked(bool)), this, SLOT(hazard_unit_change()));
-    connect(ui->hazard_stall_forward, SIGNAL(clicked(bool)), this, SLOT(hazard_unit_change()));
+    connect(ui->pipelined, &QAbstractButton::clicked, this,
+            &NewDialog::pipelined_change);
+    connect(ui->delay_slot, &QAbstractButton::clicked, this,
+            &NewDialog::delay_slot_change);
+    connect(ui->hazard_unit, &QGroupBox::clicked, this,
+            &NewDialog::hazard_unit_change);
+    connect(ui->hazard_stall, &QAbstractButton::clicked, this,
+            &NewDialog::hazard_unit_change);
+    connect(ui->hazard_stall_forward, &QAbstractButton::clicked, this,
+            &NewDialog::hazard_unit_change);
 
-    connect(ui->mem_protec_exec, SIGNAL(clicked(bool)), this, SLOT(mem_protec_exec_change(bool)));
-    connect(ui->mem_protec_write, SIGNAL(clicked(bool)), this, SLOT(mem_protec_write_change(bool)));
-    connect(ui->mem_time_read, SIGNAL(valueChanged(int)), this, SLOT(mem_time_read_change(int)));
-    connect(ui->mem_time_write, SIGNAL(valueChanged(int)), this, SLOT(mem_time_write_change(int)));
-    connect(ui->mem_time_burst, SIGNAL(valueChanged(int)), this, SLOT(mem_time_burst_change(int)));
+    connect(ui->mem_protec_exec, &QAbstractButton::clicked, this,
+            &NewDialog::mem_protec_exec_change);
+    connect(ui->mem_protec_write, &QAbstractButton::clicked, this,
+            &NewDialog::mem_protec_write_change);
+    connect(ui->mem_time_read, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &NewDialog::mem_time_read_change);
+    connect(ui->mem_time_write, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &NewDialog::mem_time_write_change);
+    connect(ui->mem_time_burst, QOverload<int>::of(&QSpinBox::valueChanged),
+            this, &NewDialog::mem_time_burst_change);
 
-    connect(ui->osemu_enable, SIGNAL(clicked(bool)), this, SLOT(osemu_enable_change(bool)));
-    connect(ui->osemu_known_syscall_stop, SIGNAL(clicked(bool)), this, SLOT(osemu_known_syscall_stop_change(bool)));
-    connect(ui->osemu_unknown_syscall_stop, SIGNAL(clicked(bool)), this, SLOT(osemu_unknown_syscall_stop_change(bool)));
-    connect(ui->osemu_interrupt_stop, SIGNAL(clicked(bool)), this, SLOT(osemu_interrupt_stop_change(bool)));
-    connect(ui->osemu_exception_stop, SIGNAL(clicked(bool)), this, SLOT(osemu_exception_stop_change(bool)));
-    connect(ui->osemu_fs_root_browse, SIGNAL(clicked(bool)), this, SLOT(browse_osemu_fs_root()));
-    connect(ui->osemu_fs_root, SIGNAL(textChanged(QString)), this, SLOT(osemu_fs_root_change(QString)));
+    connect(ui->osemu_enable, &QAbstractButton::clicked, this,
+            &NewDialog::osemu_enable_change);
+    connect(ui->osemu_known_syscall_stop, &QAbstractButton::clicked, this,
+            &NewDialog::osemu_known_syscall_stop_change);
+    connect(ui->osemu_unknown_syscall_stop, &QAbstractButton::clicked, this,
+            &NewDialog::osemu_unknown_syscall_stop_change);
+    connect(ui->osemu_interrupt_stop, &QAbstractButton::clicked, this,
+            &NewDialog::osemu_interrupt_stop_change);
+    connect(ui->osemu_exception_stop, &QAbstractButton::clicked, this,
+            &NewDialog::osemu_exception_stop_change);
+    connect(ui->osemu_fs_root_browse, &QAbstractButton::clicked, this,
+            &NewDialog::browse_osemu_fs_root);
+    connect(ui->osemu_fs_root, &QLineEdit::textChanged, this,
+            &NewDialog::osemu_fs_root_change);
 
-	cache_handler_d = new NewDialogCacheHandler(this, ui_cache_d);
-	cache_handler_p = new NewDialogCacheHandler(this, ui_cache_p);
+    cache_handler_d = new NewDialogCacheHandler(this, ui_cache_d);
+    cache_handler_p = new NewDialogCacheHandler(this, ui_cache_p);
 
     // TODO remove this block when protections are implemented
     ui->mem_protec_exec->setVisible(false);
@@ -369,15 +396,21 @@ void NewDialog::store_settings() {
 }
 
 NewDialogCacheHandler::NewDialogCacheHandler(NewDialog *nd, Ui::NewDialogCache *cui) {
-	this->nd = nd;
-	this->ui = cui;
-	this->config = nullptr;
-	connect(ui->enabled, SIGNAL(clicked(bool)), this, SLOT(enabled(bool)));
-	connect(ui->number_of_sets, SIGNAL(editingFinished()), this, SLOT(numsets()));
-	connect(ui->block_size, SIGNAL(editingFinished()), this, SLOT(blocksize()));
-	connect(ui->degree_of_associativity, SIGNAL(editingFinished()), this, SLOT(degreeassociativity()));
-	connect(ui->replacement_policy, SIGNAL(activated(int)), this, SLOT(replacement(int)));
-	connect(ui->writeback_policy, SIGNAL(activated(int)), this, SLOT(writeback(int)));
+  this->nd = nd;
+  this->ui = cui;
+  this->config = nullptr;
+  connect(ui->enabled, &QGroupBox::clicked, this,
+          &NewDialogCacheHandler::enabled);
+  connect(ui->number_of_sets, &QAbstractSpinBox::editingFinished, this,
+          &NewDialogCacheHandler::numsets);
+  connect(ui->block_size, &QAbstractSpinBox::editingFinished, this,
+          &NewDialogCacheHandler::blocksize);
+  connect(ui->degree_of_associativity, &QAbstractSpinBox::editingFinished, this,
+          &NewDialogCacheHandler::degreeassociativity);
+  connect(ui->replacement_policy, QOverload<int>::of(&QComboBox::activated),
+          this, &NewDialogCacheHandler::replacement);
+  connect(ui->writeback_policy, QOverload<int>::of(&QComboBox::activated), this,
+          &NewDialogCacheHandler::writeback);
 }
 
 void NewDialogCacheHandler::set_config(machine::MachineConfigCache *config) {

--- a/qtmips_gui/newdialog.h
+++ b/qtmips_gui/newdialog.h
@@ -95,18 +95,18 @@ private:
 	NewDialogCacheHandler *cache_handler_p, *cache_handler_d;
 };
 
-class NewDialogCacheHandler : QObject {
-	Q_OBJECT
+class NewDialogCacheHandler : public QObject {
+  Q_OBJECT
 public:
-	NewDialogCacheHandler(NewDialog *nd, Ui::NewDialogCache *ui);
+  NewDialogCacheHandler(NewDialog *nd, Ui::NewDialogCache *ui);
 
-    void set_config(machine::MachineConfigCache *config);
+  void set_config(machine::MachineConfigCache *config);
 
-    void config_gui();
+  void config_gui();
 
 private slots:
-	void enabled(bool);
-	void numsets();
+  void enabled(bool);
+  void numsets();
 	void blocksize();
 	void degreeassociativity();
 	void replacement(int);

--- a/qtmips_gui/peripheralsview.cpp
+++ b/qtmips_gui/peripheralsview.cpp
@@ -1,22 +1,26 @@
 #include "peripheralsview.h"
 #include "ui_peripheralsview.h"
 
-PeripheralsView::PeripheralsView(QWidget *parent) :
-    QWidget(parent),
-    ui(new Ui::PeripheralsView)
-{
-    ui->setupUi(this);
+PeripheralsView::PeripheralsView(QWidget *parent)
+    : QWidget(parent), ui(new Ui::PeripheralsView) {
+  ui->setupUi(this);
 
-    ui->dialRed->setStyleSheet("QDial { background-color: red }");
-    ui->dialGreen->setStyleSheet("QDial { background-color: green }");
-    ui->dialBlue->setStyleSheet("QDial { background-color: blue }");
+  ui->dialRed->setStyleSheet("QDial { background-color: red }");
+  ui->dialGreen->setStyleSheet("QDial { background-color: green }");
+  ui->dialBlue->setStyleSheet("QDial { background-color: blue }");
 
-    connect(ui->dialRed, SIGNAL(valueChanged(int)), ui->spinRed, SLOT(setValue(int)));
-    connect(ui->dialGreen, SIGNAL(valueChanged(int)), ui->spinGreen, SLOT(setValue(int)));
-    connect(ui->dialBlue, SIGNAL(valueChanged(int)), ui->spinBlue, SLOT(setValue(int)));
-    connect(ui->spinRed, SIGNAL(valueChanged(int)), ui->dialRed, SLOT(setValue(int)));
-    connect(ui->spinGreen, SIGNAL(valueChanged(int)), ui->dialGreen, SLOT(setValue(int)));
-    connect(ui->spinBlue, SIGNAL(valueChanged(int)), ui->dialBlue, SLOT(setValue(int)));
+  connect(ui->dialRed, &QAbstractSlider::valueChanged, ui->spinRed,
+          &QSpinBox::setValue);
+  connect(ui->dialGreen, &QAbstractSlider::valueChanged, ui->spinGreen,
+          &QSpinBox::setValue);
+  connect(ui->dialBlue, &QAbstractSlider::valueChanged, ui->spinBlue,
+          &QSpinBox::setValue);
+  connect(ui->spinRed, QOverload<int>::of(&QSpinBox::valueChanged), ui->dialRed,
+          &QAbstractSlider::setValue);
+  connect(ui->spinGreen, QOverload<int>::of(&QSpinBox::valueChanged),
+          ui->dialGreen, &QAbstractSlider::setValue);
+  connect(ui->spinBlue, QOverload<int>::of(&QSpinBox::valueChanged),
+          ui->dialBlue, &QAbstractSlider::setValue);
 }
 
 PeripheralsView::~PeripheralsView()
@@ -25,42 +29,53 @@ PeripheralsView::~PeripheralsView()
 }
 
 void PeripheralsView::setup(const machine::PeripSpiLed *perip_spi_led) {
-    int val;
+  int val;
 
-    connect(ui->spinRed, SIGNAL(valueChanged(int)), perip_spi_led, SLOT(red_knob_update(int)));
-    connect(ui->spinGreen, SIGNAL(valueChanged(int)), perip_spi_led, SLOT(green_knob_update(int)));
-    connect(ui->spinBlue, SIGNAL(valueChanged(int)), perip_spi_led, SLOT(blue_knob_update(int)));
+  connect(ui->spinRed, QOverload<int>::of(&QSpinBox::valueChanged),
+          perip_spi_led, &machine::PeripSpiLed::red_knob_update);
+  connect(ui->spinGreen, QOverload<int>::of(&QSpinBox::valueChanged),
+          perip_spi_led, &machine::PeripSpiLed::green_knob_update);
+  connect(ui->spinBlue, QOverload<int>::of(&QSpinBox::valueChanged),
+          perip_spi_led, &machine::PeripSpiLed::blue_knob_update);
 
-    val = ui->spinRed->value();
-    ui->spinRed->setValue(val - 1);
-    ui->spinRed->setValue(val);
+  val = ui->spinRed->value();
+  ui->spinRed->setValue(val - 1);
+  ui->spinRed->setValue(val);
 
-    val = ui->spinGreen->value();
-    ui->spinGreen->setValue(val - 1);
-    ui->spinGreen->setValue(val);
+  val = ui->spinGreen->value();
+  ui->spinGreen->setValue(val - 1);
+  ui->spinGreen->setValue(val);
 
-    val = ui->spinBlue->value();
-    ui->spinBlue->setValue(val - 1);
-    ui->spinBlue->setValue(val);
+  val = ui->spinBlue->value();
+  ui->spinBlue->setValue(val - 1);
+  ui->spinBlue->setValue(val);
 
-    connect(ui->checkRed, SIGNAL(clicked(bool)), perip_spi_led, SLOT(red_knob_push(bool)));
-    connect(ui->checkGreen, SIGNAL(clicked(bool)), perip_spi_led, SLOT(green_knob_push(bool)));
-    connect(ui->checkBlue, SIGNAL(clicked(bool)), perip_spi_led, SLOT(blue_knob_push(bool)));
+  connect(ui->checkRed, &QAbstractButton::clicked, perip_spi_led,
+          &machine::PeripSpiLed::red_knob_push);
+  connect(ui->checkGreen, &QAbstractButton::clicked, perip_spi_led,
+          &machine::PeripSpiLed::green_knob_push);
+  connect(ui->checkBlue, &QAbstractButton::clicked, perip_spi_led,
+          &machine::PeripSpiLed::blue_knob_push);
 
-    ui->checkRed->setChecked(false);
-    ui->checkGreen->setChecked(false);;
-    ui->checkBlue->setChecked(false);;
+  ui->checkRed->setChecked(false);
+  ui->checkGreen->setChecked(false);
+  ;
+  ui->checkBlue->setChecked(false);
+  ;
 
-    ui->labelRgb1->setAutoFillBackground(true);
-    ui->labelRgb2->setAutoFillBackground(true);
+  ui->labelRgb1->setAutoFillBackground(true);
+  ui->labelRgb2->setAutoFillBackground(true);
 
-    connect(perip_spi_led, SIGNAL(led_line_changed(uint)), this, SLOT(led_line_changed(uint)));
-    connect(perip_spi_led, SIGNAL(led_rgb1_changed(uint)), this, SLOT(led_rgb1_changed(uint)));
-    connect(perip_spi_led, SIGNAL(led_rgb2_changed(uint)), this, SLOT(led_rgb2_changed(uint)));
+  connect(perip_spi_led, &machine::PeripSpiLed::led_line_changed, this,
+          &PeripheralsView::led_line_changed);
+  connect(perip_spi_led, &machine::PeripSpiLed::led_rgb1_changed, this,
+          &PeripheralsView::led_rgb1_changed);
+  connect(perip_spi_led, &machine::PeripSpiLed::led_rgb2_changed, this,
+          &PeripheralsView::led_rgb2_changed);
 
-    led_line_changed(0);
-    led_rgb1_changed(0);
-    led_rgb2_changed(0);
+  led_line_changed(0);
+  led_rgb1_changed(0);
+  led_rgb2_changed(0);
 }
 
 void PeripheralsView::led_line_changed(uint val) {

--- a/qtmips_gui/programmodel.cpp
+++ b/qtmips_gui/programmodel.cpp
@@ -175,10 +175,11 @@ void ProgramModel::setup(machine::QtMipsMachine *machine) {
     for (int i = 0 ; i < STAGEADDR_COUNT; i++)
         stage_addr[i] = machine::STAGEADDR_NONE;
     if (machine != nullptr)
-        connect(machine, SIGNAL(post_tick()), this, SLOT(check_for_updates()));
+      connect(machine, &machine::QtMipsMachine::post_tick, this,
+              &ProgramModel::check_for_updates);
     if (mem_access() != nullptr)
-        connect(mem_access(), SIGNAL(external_change_notify(const MemoryAccess*,std::uint32_t,std::uint32_t,bool)),
-                this, SLOT(check_for_updates()));
+      connect(mem_access(), &machine::MemoryAccess::external_change_notify,
+              this, &ProgramModel::check_for_updates);
     emit update_all();
 }
 

--- a/qtmips_gui/programtableview.cpp
+++ b/qtmips_gui/programtableview.cpp
@@ -44,16 +44,16 @@
 #include "hinttabledelegate.h"
 
 ProgramTableView::ProgramTableView(QWidget *parent, QSettings *settings) : Super(parent) {
-    setItemDelegate(new HintTableDelegate);
-    connect(verticalScrollBar() , SIGNAL(valueChanged(int)),
-            this, SLOT(adjust_scroll_pos_check()));
-    connect(this , SIGNAL(adjust_scroll_pos_queue()),
-            this, SLOT(adjust_scroll_pos_process()), Qt::QueuedConnection);
-    this->settings = settings;
-    initial_address = settings->value("ProgramViewAddr0", 0).toULongLong();
-    adjust_scroll_pos_in_progress = false;
-    need_addr0_save = false;
-    setTextElideMode(Qt::ElideNone);
+  setItemDelegate(new HintTableDelegate);
+  connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this,
+          &ProgramTableView::adjust_scroll_pos_check);
+  connect(this, &ProgramTableView::adjust_scroll_pos_queue, this,
+          &ProgramTableView::adjust_scroll_pos_process, Qt::QueuedConnection);
+  this->settings = settings;
+  initial_address = settings->value("ProgramViewAddr0", 0).toULongLong();
+  adjust_scroll_pos_in_progress = false;
+  need_addr0_save = false;
+  setTextElideMode(Qt::ElideNone);
 }
 
 void ProgramTableView::addr0_save_change(std::uint32_t val) {

--- a/qtmips_gui/registersdock.cpp
+++ b/qtmips_gui/registersdock.cpp
@@ -140,14 +140,19 @@ void RegistersDock::setup(machine::QtMipsMachine *machine) {
     labelVal(hi, regs->read_hi_lo(true));
     labelVal(lo, regs->read_hi_lo(false));
     for (int i = 0; i < 32; i++)
-        labelVal(gp[i], regs->read_gp(i));
+      labelVal(gp[i], regs->read_gp(i));
 
-    connect(regs, SIGNAL(pc_update(std::uint32_t)), this, SLOT(pc_changed(std::uint32_t)));
-    connect(regs, SIGNAL(gp_update(std::uint8_t,std::uint32_t)), this, SLOT(gp_changed(std::uint8_t,std::uint32_t)));
-    connect(regs, SIGNAL(hi_lo_update(bool,std::uint32_t)), this, SLOT(hi_lo_changed(bool,std::uint32_t)));
-    connect(regs, SIGNAL(gp_read(std::uint8_t,std::uint32_t)), this, SLOT(gp_read(std::uint8_t,std::uint32_t)));
-    connect(regs, SIGNAL(hi_lo_read(bool,std::uint32_t)), this, SLOT(hi_lo_read(bool,std::uint32_t)));
-    connect(machine, SIGNAL(tick()), this, SLOT(clear_highlights()));
+    connect(regs, &machine::Registers::pc_update, this,
+            &RegistersDock::pc_changed);
+    connect(regs, &machine::Registers::gp_update, this,
+            &RegistersDock::gp_changed);
+    connect(regs, &machine::Registers::hi_lo_update, this,
+            &RegistersDock::hi_lo_changed);
+    connect(regs, &machine::Registers::gp_read, this, &RegistersDock::gp_read);
+    connect(regs, &machine::Registers::hi_lo_read, this,
+            &RegistersDock::hi_lo_read);
+    connect(machine, &machine::QtMipsMachine::tick, this,
+            &RegistersDock::clear_highlights);
 }
 
 void RegistersDock::pc_changed(std::uint32_t val) {

--- a/qtmips_gui/savechangeddialog.cpp
+++ b/qtmips_gui/savechangeddialog.cpp
@@ -84,9 +84,12 @@ SaveChnagedDialog::SaveChnagedDialog(QStringList &changedlist, QWidget *parent) 
     QPushButton *ignoreButton = new QPushButton(tr("&Ignore"), parent);
     QPushButton *saveButton = new QPushButton(tr("&Save"), parent);
     saveButton->setFocus();
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancel_clicked()));
-    connect(ignoreButton, SIGNAL(clicked()), this, SLOT(ignore_clicked()));
-    connect(saveButton, SIGNAL(clicked()), this, SLOT(save_clicked()));
+    connect(cancelButton, &QAbstractButton::clicked, this,
+            &SaveChnagedDialog::cancel_clicked);
+    connect(ignoreButton, &QAbstractButton::clicked, this,
+            &SaveChnagedDialog::ignore_clicked);
+    connect(saveButton, &QAbstractButton::clicked, this,
+            &SaveChnagedDialog::save_clicked);
     hlBtn->addWidget(cancelButton);
     hlBtn->addStretch();
     hlBtn->addWidget(ignoreButton);

--- a/qtmips_gui/terminaldock.cpp
+++ b/qtmips_gui/terminaldock.cpp
@@ -65,13 +65,14 @@ TerminalDock::~TerminalDock() {
 }
 
 void TerminalDock::setup(machine::SerialPort *ser_port) {
-    if (ser_port == nullptr)
-        return;
-    connect(ser_port, SIGNAL(tx_byte(uint)), this, SLOT(tx_byte(uint)));
-    connect(ser_port, SIGNAL(rx_byte_pool(int,uint&,bool&)),
-            this, SLOT(rx_byte_pool(int,uint&,bool&)));
-    connect(input_edit, SIGNAL(textChanged(QString)),
-            ser_port, SLOT(rx_queue_check()));
+  if (ser_port == nullptr)
+    return;
+  connect(ser_port, &machine::SerialPort::tx_byte, this,
+          QOverload<unsigned int>::of(&TerminalDock::tx_byte));
+  connect(ser_port, &machine::SerialPort::rx_byte_pool, this,
+          &TerminalDock::rx_byte_pool);
+  connect(input_edit, &QLineEdit::textChanged, ser_port,
+          &machine::SerialPort::rx_queue_check);
 }
 
 void TerminalDock::tx_byte(unsigned int data) {

--- a/qtmips_gui/textsignalaction.cpp
+++ b/qtmips_gui/textsignalaction.cpp
@@ -37,29 +37,34 @@
 #include "textsignalaction.h"
 
 TextSignalAction::TextSignalAction(QObject *parent) : Super(parent) {
-    connect(this, SIGNAL(triggered(bool)), this, SLOT(process_triggered(bool)));
+  connect(this, &TextSignalAction::triggered, this,
+          &TextSignalAction::process_triggered);
 }
 
 TextSignalAction::TextSignalAction(const QString &text, QObject *parent) :
     Super(text, parent), signal_text(text) {
-    connect(this, SIGNAL(triggered(bool)), this, SLOT(process_triggered(bool)));
+  connect(this, &TextSignalAction::triggered, this,
+          &TextSignalAction::process_triggered);
 }
 
 TextSignalAction::TextSignalAction(const QString &text, const QString &signal_text,
                  QObject *parent) :
     Super(text, parent), signal_text(signal_text) {
-    connect(this, SIGNAL(triggered(bool)), this, SLOT(process_triggered(bool)));
+  connect(this, &TextSignalAction::triggered, this,
+          &TextSignalAction::process_triggered);
 }
 
 TextSignalAction::TextSignalAction(const QIcon &icon, const QString &text, QObject *parent) :
     Super(icon, text, parent), signal_text(text) {
-    connect(this, SIGNAL(triggered(bool)), this, SLOT(process_triggered(bool)));
+  connect(this, &TextSignalAction::triggered, this,
+          &TextSignalAction::process_triggered);
 }
 
 TextSignalAction::TextSignalAction(const QIcon &icon, const QString &text, const QString &signal_text,
                  QObject *parent) :
     Super(icon, text, parent), signal_text(signal_text) {
-    connect(this, SIGNAL(triggered(bool)), this, SLOT(process_triggered(bool)));
+  connect(this, &TextSignalAction::triggered, this,
+          &TextSignalAction::process_triggered);
 }
 
 void TextSignalAction::process_triggered(bool checked) {

--- a/qtmips_machine/physaddrspace.cpp
+++ b/qtmips_machine/physaddrspace.cpp
@@ -93,17 +93,19 @@ PhysAddrSpace::RangeDesc *PhysAddrSpace::find_range(std::uint32_t address) const
 }
 
 bool PhysAddrSpace::insert_range(MemoryAccess *mem_acces, std::uint32_t start_addr, std::uint32_t last_addr, bool move_ownership) {
-    RangeDesc *p_range = new RangeDesc(mem_acces, start_addr, last_addr, move_ownership);
-    auto i = ranges_by_addr.lowerBound(start_addr);
-    if (i != ranges_by_addr.end()) {
-        if (i.value()->start_addr <= last_addr && i.value()->last_addr >= start_addr)
-            return false;
-    }
-    ranges_by_addr.insert(last_addr, p_range);
-    ranges_by_access.insertMulti(mem_acces, p_range);
-    connect(mem_acces, SIGNAL(external_change_notify(const MemoryAccess*,std::uint32_t,std::uint32_t,bool)),
-            this, SLOT(range_external_change(const MemoryAccess*,std::uint32_t,std::uint32_t,bool)));
-    return true;
+  RangeDesc *p_range =
+      new RangeDesc(mem_acces, start_addr, last_addr, move_ownership);
+  auto i = ranges_by_addr.lowerBound(start_addr);
+  if (i != ranges_by_addr.end()) {
+    if (i.value()->start_addr <= last_addr &&
+        i.value()->last_addr >= start_addr)
+      return false;
+  }
+  ranges_by_addr.insert(last_addr, p_range);
+  ranges_by_access.insertMulti(mem_acces, p_range);
+  connect(mem_acces, &MemoryAccess::external_change_notify, this,
+          &PhysAddrSpace::range_external_change);
+  return true;
 }
 
 bool PhysAddrSpace::remove_range(MemoryAccess *mem_acces) {


### PR DESCRIPTION
Member pointers better than strings. Typechecked.
Requires QObject to be public parent.